### PR TITLE
learned_dscp is a uint8_t and not a unsigned short, pass u to printf ins...

### DIFF
--- a/pcp_app/pcp_app.c
+++ b/pcp_app/pcp_app.c
@@ -356,7 +356,7 @@ static void print_get_dscp(pcp_flow_t* f)
      for (; cnt>0; cnt--, ret++) {
          char ntop_buff[INET6_ADDRSTRLEN];
          char timebuf[32];
-         printf("%-20s %5hu %3d %5s %s",
+         printf("%-20s %5u %3d %5s %s",
                  inet_ntop(AF_INET6, &ret->int_ip, ntop_buff,
                      sizeof(ntop_buff)),
                  ret->learned_dscp,


### PR DESCRIPTION
Hi
libpcp doesn't compile with clang without this fix. I get:

```
pcp_app.c:362:18: error: format specifies type 'unsigned short' but the argument has type 'uint8_t' (aka 'unsigned char') [-Werror,-Wformat]
                 ret->learned_dscp,
             ^~~~~~~~~~~~~~~~~
1 error generated.
```

I have successfully compiled with both clang and gcc after modifying the code. All tests pass as well.
