### PR TITLE
linklocal IPv6 address support

### DIFF
--- a/libpcp/src/net/gateway.h
+++ b/libpcp/src/net/gateway.h
@@ -26,8 +26,8 @@
 #ifndef __GETGATEWAY_H__
 #define __GETGATEWAY_H__
 
-struct in6_addr;
+struct sockaddr_in6;
 
-int getgateways(struct in6_addr **gws);
+int getgateways(struct sockaddr_in6 **gws);
 
 #endif

--- a/libpcp/src/net/pcp_socket.c
+++ b/libpcp/src/net/pcp_socket.c
@@ -139,7 +139,7 @@ void pcp_fill_in6_addr(struct in6_addr *dst_ip6, uint16_t *dst_port,
 }
 
 void pcp_fill_sockaddr(struct sockaddr *dst, struct in6_addr *sip,
-        uint16_t sport, int ret_ipv6_mapped_ipv4)
+        uint16_t sport, int ret_ipv6_mapped_ipv4, uint32_t scope_id)
 {
     if ((!ret_ipv6_mapped_ipv4) && (IN6_IS_ADDR_V4MAPPED(sip))) {
         struct sockaddr_in *s=(struct sockaddr_in *)dst;
@@ -154,6 +154,7 @@ void pcp_fill_sockaddr(struct sockaddr *dst, struct in6_addr *sip,
         s->sin6_family=AF_INET6;
         s->sin6_addr=*sip;
         s->sin6_port=sport;
+        s->sin6_scope_id=scope_id;
         SET_SA_LEN(s, sizeof(struct sockaddr_in6));
     }
 }

--- a/libpcp/src/net/pcp_socket.h
+++ b/libpcp/src/net/pcp_socket.h
@@ -70,7 +70,7 @@ void pcp_fill_in6_addr(struct in6_addr *dst_ip6, uint16_t *dst_port,
         struct sockaddr *src);
 
 void pcp_fill_sockaddr(struct sockaddr *dst, struct in6_addr *sip,
-        uint16_t sport, int ret_ipv6_mapped_ipv4);
+        uint16_t sport, int ret_ipv6_mapped_ipv4, uint32_t scope_id);
 
 PCP_SOCKET pcp_socket_create(struct pcp_ctx_s *ctx, int domain, int type,
         int protocol);

--- a/libpcp/src/pcp_client_db.c
+++ b/libpcp/src/pcp_client_db.c
@@ -272,7 +272,7 @@ void pcp_db_add_md(pcp_flow_t *f, uint16_t md_id, void *val, size_t val_len)
 }
 #endif
 
-int pcp_new_server(pcp_ctx_t *ctx, struct in6_addr *ip, uint16_t port)
+int pcp_new_server(pcp_ctx_t *ctx, struct in6_addr *ip, uint16_t port, uint32_t scope_id)
 {
     uint32_t i;
     pcp_server_t *ret=NULL;
@@ -333,6 +333,7 @@ int pcp_new_server(pcp_ctx_t *ctx, struct in6_addr *ip, uint16_t port)
 #endif
     IPV6_ADDR_COPY((struct in6_addr*)ret->pcp_ip, ip);
     ret->pcp_port=port;
+    ret->pcp_scope_id=scope_id;
     ret->ctx=ctx;
     ret->server_state=pss_allocated;
     ret->pcp_version=PCP_MAX_SUPPORTED_VERSION;

--- a/libpcp/src/pcp_client_db.h
+++ b/libpcp/src/pcp_client_db.h
@@ -196,6 +196,7 @@ struct pcp_server {
     uint32_t af;
     uint32_t pcp_ip[4];
     uint16_t pcp_port;
+    uint32_t pcp_scope_id;
     uint32_t src_ip[4];
     char pcp_server_paddr[INET6_ADDRSTRLEN];
     struct sockaddr_storage pcp_server_saddr;
@@ -237,7 +238,7 @@ void pcp_flow_clear_msg_buf(pcp_flow_t *f);
 void pcp_db_add_md(pcp_flow_t *f, uint16_t md_id, void *val, size_t val_len);
 #endif
 
-int pcp_new_server(pcp_ctx_t *ctx, struct in6_addr *ip, uint16_t port);
+int pcp_new_server(pcp_ctx_t *ctx, struct in6_addr *ip, uint16_t port, uint32_t scope_id);
 
 pcp_errno pcp_db_foreach_server(pcp_ctx_t *ctx, pcp_db_server_iterate f,
         void *data);

--- a/libpcp/src/pcp_event_handler.c
+++ b/libpcp/src/pcp_event_handler.c
@@ -1335,10 +1335,11 @@ static void flow_change_notify(pcp_flow_t *flow, pcp_fstate_e state)
 
     if (ctx->flow_change_cb_fun) {
         pcp_fill_sockaddr((struct sockaddr*)&src_addr, &flow->kd.src_ip,
-                flow->kd.map_peer.src_port, 0);
+                flow->kd.map_peer.src_port, 0, 0/* scope_id */);
         if (state == pcp_state_succeeded) {
             pcp_fill_sockaddr((struct sockaddr*)&ext_addr,
-                    &flow->map_peer.ext_ip, flow->map_peer.ext_port, 0);
+                    &flow->map_peer.ext_ip, flow->map_peer.ext_port, 0,
+                    0/* scope_id */);
         } else {
             memset(&ext_addr, 0, sizeof(ext_addr));
             ext_addr.ss_family=AF_INET;


### PR DESCRIPTION
use scope_id information in order to be able to use linklocal IPv6 addresses

Retrieve the interface index from RTA_OIF
it does work 
