### PR TITLE
Fixed OS X compilation (works at least on 10.9 now).

### DIFF
--- a/libpcp/src/net/gateway.c
+++ b/libpcp/src/net/gateway.c
@@ -485,9 +485,9 @@ int getgateways(struct sockaddr_in6 **gws)
                 if (sa->sa_family == AF_INET) {
                     /* IPv4 gateways as returned as IPv4 mapped IPv6 addresses */
                     in6->sin6_family = AF_INET6;
-                    in6->sin6_addr.s6_addr32[0]=
+                    S6_ADDR32(&in6->sin6_addr)[0]=
                             ((struct sockaddr_in *)(rti_info[RTAX_GATEWAY]))->sin_addr.s_addr;
-                    TO_IPV6MAPPED(in6);
+                    TO_IPV6MAPPED(&in6->sin6_addr);
                 } else if (sa->sa_family == AF_INET6) {
                     memcpy(in6,
                             (struct sockaddr_in6 *)rti_info[RTAX_GATEWAY],

--- a/libpcp/src/pcp_utils.h
+++ b/libpcp/src/pcp_utils.h
@@ -122,27 +122,6 @@
 
 #define OSDEP(x) (void)(x)
 
-/* Getting rid of Apple's lack of s6_addr32 definition causing compilation warnings */
-#if defined(__APPLE__)
-
-#ifndef s6_addr32
-    #define s6_addr32   __u6_addr.__u6_addr32
-#endif
-#undef IN6_IS_ADDR_V4MAPPED
-#define IN6_IS_ADDR_V4MAPPED(a)           \
-    ((*(const __uint32_t *)(const void *)(&(a)->s6_addr32[0]) == 0) && \
-     (*(const __uint32_t *)(const void *)(&(a)->s6_addr32[1]) == 0) && \
-     (*(const __uint32_t *)(const void *)(&(a)->s6_addr32[2]) == ntohl(0x0000ffff)))
-
-#undef IN6_IS_ADDR_UNSPECIFIED
-#define IN6_IS_ADDR_UNSPECIFIED(a)  \
-    ((*(const __uint32_t *)(const void *)(&(a)->s6_addr32[0]) == 0) && \
-     (*(const __uint32_t *)(const void *)(&(a)->s6_addr32[1]) == 0) && \
-     (*(const __uint32_t *)(const void *)(&(a)->s6_addr32[2]) == 0) && \
-     (*(const __uint32_t *)(const void *)(&(a)->s6_addr32[3]) == 0))
-
-#endif
-
 #ifdef s6_addr32
 #define S6_ADDR32(sa6) (sa6)->s6_addr32
 #else


### PR DESCRIPTION
All of that s6_addr32 magic a) wasn't needed (there was just one place using it), and b) didn't seem to even work.

Also in gateway.c I think there was even wild typecasting caused (platform independent) bug as it used sockaddr_in6 as if it was in6_addr.
