### PR TITLE
libpcp: pcp_event_handler: check for integer overflow

### DIFF
--- a/libpcp/src/pcp_event_handler.c
+++ b/libpcp/src/pcp_event_handler.c
@@ -481,9 +481,11 @@ static pcp_flow_event_e fhndl_received_success(pcp_flow_t *f,
     struct timeval ctv;
 
     PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
-    f->recv_lifetime=msg->received_time + msg->recv_lifetime;
-    if (msg->received_time > f->recv_lifetime){
-        f->recv_lifetime= LONG_MAX;
+    // avoid integer overflow
+    if (msg->recv_lifetime > (time_t) LONG_MAX - msg->received_time) {
+        f->recv_lifetime = LONG_MAX;
+    } else {
+        f->recv_lifetime = msg->received_time + msg->recv_lifetime;
     }
     if ((f->kd.operation == PCP_OPCODE_MAP)
             || (f->kd.operation == PCP_OPCODE_PEER)) {

--- a/libpcp/src/pcp_event_handler.c
+++ b/libpcp/src/pcp_event_handler.c
@@ -37,6 +37,7 @@
 #include <errno.h>
 #include <time.h>
 #include <assert.h>
+#include <limits.h>
 
 #ifdef WIN32
 #include "pcp_win_defines.h"
@@ -481,6 +482,9 @@ static pcp_flow_event_e fhndl_received_success(pcp_flow_t *f,
 
     PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
     f->recv_lifetime=msg->received_time + msg->recv_lifetime;
+    if (msg->received_time > f->recv_lifetime){
+        f->recv_lifetime= LONG_MAX;
+    }
     if ((f->kd.operation == PCP_OPCODE_MAP)
             || (f->kd.operation == PCP_OPCODE_PEER)) {
         f->map_peer.ext_ip=msg->assigned_ext_ip;


### PR DESCRIPTION
Calculating recv_lifetime can result in an integer overflow, with 32 bits time_t.
Value could be truncated to LONG_MAX in this case.