### PR TITLE
Preserve IP address family for IPv4 0.0.0.0 (ANY) address

### DIFF
--- a/libpcp/src/net/pcp_socket.c
+++ b/libpcp/src/net/pcp_socket.c
@@ -114,16 +114,10 @@ void pcp_fill_in6_addr(struct in6_addr *dst_ip6, uint16_t *dst_port,
         struct sockaddr_in *src_ip4=(struct sockaddr_in *)src;
 
         if (dst_ip6) {
-            if (src_ip4->sin_addr.s_addr != INADDR_ANY) {
-                S6_ADDR32(dst_ip6)[0]=0;
-                S6_ADDR32(dst_ip6)[1]=0;
-                S6_ADDR32(dst_ip6)[2]=htonl(0xFFFF);
-                S6_ADDR32(dst_ip6)[3]=src_ip4->sin_addr.s_addr;
-            } else {
-                unsigned i;
-                for (i=0; i < 4; ++i)
-                    S6_ADDR32(dst_ip6)[i]=0;
-            }
+            S6_ADDR32(dst_ip6)[0]=0;
+            S6_ADDR32(dst_ip6)[1]=0;
+            S6_ADDR32(dst_ip6)[2]=htonl(0xFFFF);
+            S6_ADDR32(dst_ip6)[3]=src_ip4->sin_addr.s_addr;
         }
         if (dst_port) {
             *dst_port=src_ip4->sin_port;

--- a/libpcp/src/pcp_api.c
+++ b/libpcp/src/pcp_api.c
@@ -355,7 +355,7 @@ static int chain_and_assign_src_ip(pcp_server_t *s, void *data)
 
     pcp_flow_t *f=NULL;
 
-    if (IN6_IS_ADDR_UNSPECIFIED(&kd.src_ip)) {
+    if (IPV6_IS_ADDR_ANY(&kd.src_ip)) {
         memcpy(&kd.src_ip, s->src_ip, sizeof(kd.src_ip));
         kd.scope_id = s->pcp_scope_id;
     }
@@ -430,7 +430,7 @@ pcp_flow_t *pcp_new_flow(pcp_ctx_t *ctx, struct sockaddr *src_addr,
                 }
                 break;
             case AF_INET6:
-                if (IN6_IS_ADDR_UNSPECIFIED(
+                if (IPV6_IS_ADDR_ANY(
                         &((struct sockaddr_in6 *)(dst_addr))->sin6_addr)) {
                     dst_addr=NULL;
                 }
@@ -448,7 +448,7 @@ pcp_flow_t *pcp_new_flow(pcp_ctx_t *ctx, struct sockaddr *src_addr,
             if (S6_ADDR32(&kd.src_ip)[3] == INADDR_ANY) {
                 findsaddr((struct sockaddr_in*)dst_addr, &kd.src_ip);
             }
-        } else if (IN6_IS_ADDR_UNSPECIFIED(&kd.src_ip)) {
+        } else if (IPV6_IS_ADDR_ANY(&kd.src_ip)) {
             findsaddr6((struct sockaddr_in6*)dst_addr, &kd.src_ip, &kd.scope_id);
         } else if (dst_addr->sa_family != src_addr->sa_family) {
             PCP_LOG(PCP_LOGLVL_PERR, "%s",

--- a/libpcp/src/pcp_event_handler.c
+++ b/libpcp/src/pcp_event_handler.c
@@ -1300,7 +1300,7 @@ int pcp_pulse(pcp_ctx_t *ctx, struct timeval *next_timeout)
             msg->pcp_server_indx=s->index;
             memcpy(&msg->kd.pcp_server_ip, s->pcp_ip, sizeof(struct in6_addr));
             pcp_fill_in6_addr(&msg->kd.src_ip, NULL, &msg->kd.scope_id, (struct sockaddr*)&msg->rcvd_to_addr);
-            if (IN6_IS_ADDR_UNSPECIFIED(&msg->kd.src_ip)) {
+            if (IPV6_IS_ADDR_ANY(&msg->kd.src_ip)) {
                 memcpy(&msg->kd.src_ip, s->src_ip, sizeof(struct in6_addr));
                 msg->kd.scope_id = scope_id;
             }

--- a/libpcp/src/pcp_server_discovery.c
+++ b/libpcp/src/pcp_server_discovery.c
@@ -147,7 +147,7 @@ void psd_add_gws(pcp_ctx_t *ctx)
         if ((IN6_IS_ADDR_V4MAPPED(&gw->sin6_addr)) && (S6_ADDR32(&gw->sin6_addr)[3] == INADDR_ANY))
             continue;
 
-        if (IN6_IS_ADDR_UNSPECIFIED(&gw->sin6_addr))
+        if (IPV6_IS_ADDR_ANY(&gw->sin6_addr))
             continue;
 
         if (get_pcp_server_by_ip(ctx, &gw->sin6_addr, gw->sin6_scope_id))

--- a/libpcp/src/pcp_utils.h
+++ b/libpcp/src/pcp_utils.h
@@ -128,6 +128,14 @@
 #define S6_ADDR32(sa6) ((uint32_t *)((sa6)->s6_addr))
 #endif
 
+#define IPV6_IS_ADDR_ANY(a) ( \
+    IN6_IS_ADDR_UNSPECIFIED(a) || \
+    (IN6_IS_ADDR_V4MAPPED(a) && (a)->s6_addr[12] == 0 && \
+                                  (a)->s6_addr[13] == 0 && \
+                                  (a)->s6_addr[14] == 0 && \
+                                  (a)->s6_addr[15] == 0) \
+)
+
 #define IPV6_ADDR_COPY(dest, src)   \
     do {                            \
         (S6_ADDR32(dest))[0]=(S6_ADDR32(src))[0];       \


### PR DESCRIPTION
Fixes #17 

- Updated `pcp_fill_in6_addr` to ensure the IPv4 0.0.0.0 (ANY) address is preserved as an IPv4-mapped IPv6 address.
- Introduced the `IPV6_IS_ADDR_ANY` macro to handle unspecified IPv6 addresses, including IPv4-mapped addresses with all-zero values.
- Replaced occurrences of `IN6_IS_ADDR_UNSPECIFIED` with `IPV6_IS_ADDR_ANY` across the codebase for consistency and clarity.

