### PR TITLE
Fix strncpy null termination bug

### DIFF
--- a/pcp_app/pcp_app.c
+++ b/pcp_app/pcp_app.c
@@ -786,7 +786,8 @@ static inline void parse_opt_location(struct pcp_params *p) {
 }
 
 static inline void parse_opt_user_id(struct pcp_params *p) {
-    strncpy(p->app_userid.userid, optarg, sizeof(p->app_userid.userid));
+    strncpy(p->app_userid.userid, optarg, sizeof(p->app_userid.userid) - 1);
+    p->app_userid.userid[sizeof(p->app_userid.userid) - 1] = '\0';
     fprintf(stderr, "Userid: %s \n", &(p->app_userid.userid[0]));
 }
 


### PR DESCRIPTION
Compiler error:
```
pcp_app.c: In function ‘main’:
pcp_app.c:789:5: error: ‘__builtin_strncpy’ specified bound 512 equals destination size [-Werror=stringop-truncation]
  789 |     strncpy(p->app_userid.userid, optarg, sizeof(p->app_userid.userid));
      |     ^
cc1: all warnings being treated as errorson]
```