### PR TITLE
win32 warning fixes

### DIFF
--- a/lib/src/net/gateway.c
+++ b/lib/src/net/gateway.c
@@ -307,7 +307,7 @@ int getgateways(struct sockaddr_in6 **gws) {
             (IPV6_IS_ADDR_ANY(&row->NextHop.Ipv6.sin6_addr))) {
             continue;
         } else if ((row->NextHop.si_family == AF_INET) &&
-                   (&row->NextHop.Ipv6.sin6_addr == INADDR_ANY)) {
+                   (row->NextHop.Ipv4.sin_addr.s_addr == INADDR_ANY)) {
             continue;
         } else if (row->NextHop.si_family == AF_INET) {
             (*gws)[ret].sin6_family = AF_INET6;

--- a/lib/src/windows/pcp_gettimeofday.h
+++ b/lib/src/windows/pcp_gettimeofday.h
@@ -26,6 +26,8 @@
 #ifndef PCP_GETTIMEOFDAY
 #define PCP_GETTIMEOFDAY
 
+struct timeval;
+struct timezone;
 int gettimeofday(struct timeval *tv, struct timezone *tz);
 
 #endif /*PCP_GETTIMEOFDAY*/


### PR DESCRIPTION
Hi, I am proposing few changes, the list list (copied from git commit message):

- WSABUF.buf is a non-const pointer but assigned by (const void *) arg
- PCP_LOG requires at least one optional argument after the format string
(not given by the call)
- gettimeofday - struct timeval/timezone declared inside parameter list
- getgateways - assumed IPv4 and then checked IPv6 address value,
incorrectly anyways - a non-zero pointer is compared to INADDR_ANY,
that is 0

All of them trigger just a warning but since the build system is using `-Werror`, it fails.

All but the last change are trivial (no functional change) - in case of the last fix (`sin6_addr`), the original condition was always false - INADDR_ANY == 0 and the pointer is certainly non-NULL because the offset of the member in enclosing structure is >0. This change seem to be coherent with the previous if-branch - the route with NextHop=0.0.0.0 should be a [loopback route](https://learn.microsoft.com/en-us/windows/win32/api/netioapi/ns-netioapi-mib_ipforward_row2).