### PR TITLE
Ensure pcp_terminate(close_flows=1) closes and removes flows; add regression test

### DIFF
--- a/lib/src/pcp_api.c
+++ b/lib/src/pcp_api.c
@@ -648,17 +648,25 @@ void pcp_delete_flow(pcp_flow_t *f) {
 }
 
 static int delete_flow_iter(pcp_flow_t *f, void *data) {
-    if (data) {
-        pcp_close_flow_intern(f);
-        pcp_pulse(f->ctx, NULL);
-    }
+    (void)data;
     pcp_delete_flow_intern(f);
 
     return 0;
 }
 
+static int close_flow_iter(pcp_flow_t *f, void *data) {
+    (void)data;
+    pcp_close_flow_intern(f);
+
+    return 0;
+}
+
 void pcp_terminate(pcp_ctx_t *ctx, int close_flows) {
-    pcp_db_foreach_flow(ctx, delete_flow_iter, close_flows ? (void *)1 : NULL);
+    if (close_flows) {
+        pcp_db_foreach_flow(ctx, close_flow_iter, NULL);
+        pcp_pulse(ctx, NULL);
+    }
+    pcp_db_foreach_flow(ctx, delete_flow_iter, NULL);
     pcp_db_free_pcp_servers(ctx);
     pcp_socket_close(ctx);
 }

--- a/tests/test_pcp_api.c
+++ b/tests/test_pcp_api.c
@@ -106,6 +106,15 @@ int main(void) {
     TEST(f1->lifetime == 0);
     TEST((f1->timeout.tv_sec > 0) || (f1->timeout.tv_usec > 0));
 
+    // regression test: pcp_terminate(close_flows=1) closes and removes flows
+    ctx = pcp_init(DISABLE_AUTODISCOVERY, NULL);
+    TEST(pcp_add_server(ctx, Sock_pton("127.0.0.1:5351"), 2) == 0);
+    TEST((f1 = pcp_new_flow(ctx, Sock_pton("127.0.0.1:1234"), NULL, NULL,
+                            IPPROTO_TCP, 100, NULL)) != NULL);
+    TEST(ctx->pcp_db.flow_cnt > 0);
+    pcp_terminate(ctx, 1);
+    TEST(ctx->pcp_db.flow_cnt == 0);
+
     printf("Tests succeeded.\n\n");
 
     PD_SOCKET_CLEANUP();


### PR DESCRIPTION
### Motivation

- Ensure that calling `pcp_terminate` with `close_flows = 1` both closes active flows and removes them from the PCP DB to avoid dangling/remaining flows.

### Description

- Change `delete_flow_iter` to ignore the `data` parameter and always perform flow deletion via `pcp_delete_flow_intern`.
- Add a new `close_flow_iter` helper that calls `pcp_close_flow_intern` for a flow without deleting it.
- Update `pcp_terminate` to call `pcp_db_foreach_flow` with `close_flow_iter` and `pcp_pulse` when `close_flows` is true, then run the delete iteration to remove flows.
- Add a regression test in `tests/test_pcp_api.c` that creates a context and flow, calls `pcp_terminate(ctx, 1)`, and asserts that `ctx->pcp_db.flow_cnt` becomes zero.

### Testing

- Built and ran the API tests in `tests/test_pcp_api.c`, including the new regression that exercises `pcp_terminate(close_flows=1)`, and the test suite completed successfully.
- The new regression test asserting `ctx->pcp_db.flow_cnt == 0` passed as part of the test run.

